### PR TITLE
passing firebase instance id through config object

### DIFF
--- a/android/FirebasePlugin.java
+++ b/android/FirebasePlugin.java
@@ -31,6 +31,8 @@ import com.google.android.gms.tasks.Task;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig;
 import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings;
 
+import com.google.firebase.iid.FirebaseInstanceId;
+
 import android.support.annotation.NonNull;
 
 import java.util.HashMap;
@@ -171,6 +173,11 @@ public class FirebasePlugin implements IPlugin, GoogleApiClient.OnConnectionFail
       while (iter.hasNext()) {
         String key = iter.next();
         String value = obj.getString(key);
+
+        if (key.equals("firebase_instance_id")) {
+          map.put(key, FirebaseInstanceId.getInstance().getId());
+          continue;
+        }
 
         map.put(key, value);
       }


### PR DESCRIPTION
firebase instance id is set in default config (this is for adding it into user model))